### PR TITLE
async ring handlers for http-kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/target
+pom.xml
+/.lein-*
+profiles.clj
+/.env
+.nrepl-port
+/.clj-kondo/.cache/
+/.lsp/.cache/
+/.calva/output-window/

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
-(defproject luminus-http-kit "0.1.9"
+(defproject luminus-http-kit "0.2.0-SNAPSHOT"
   :description "HTTP Kit adapter for Luminus"
   :url "https://github.com/luminus-framework/luminus-http-kit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.logging "0.4.0"]
-                 [http-kit "2.5.0"]])
+  :plugins [[lein-ancient "1.0.0-RC3"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [http-kit "2.6.0"]])

--- a/src/luminus/http_server.clj
+++ b/src/luminus/http_server.clj
@@ -2,11 +2,25 @@
   (:require [clojure.tools.logging :as log]
             [org.httpkit.server :as http-kit]))
 
-(defn start [{:keys [handler host port] :as opts}]
+;; i know nothing about http-kit, but this blog post has a conversion function
+;; https://www.booleanknot.com/blog/2016/07/15/asynchronous-ring.html
+;; with-channel is deprecated though, so i rewrote it to use as-channel
+(defn async-ring->httpkit2 [handler]
+  (fn [request]
+    (http-kit/as-channel
+     request
+     {:on-open (fn [ch]
+                 (handler request
+                          #(http-kit/send! ch %)
+                          (fn [_] (http-kit/close ch))))})))
+
+(defn start [{:keys [handler host port async?] :as opts}]
   (try
     (log/info "starting HTTP server on port" port)
     (http-kit/run-server
-      handler
+      (if async?
+        (async-ring->httpkit2 handler)
+        handler)
       (-> opts
           (assoc  :legacy-return-value? false)
           (dissoc :handler :init)))


### PR DESCRIPTION
https://www.booleanknot.com/blog/2016/07/15/asynchronous-ring.html

had a conversion function from http-kit to async ring, except with-channel is deprecated so I changed it to the new API.